### PR TITLE
Expand website into multi-page experience for G5 Bygg AB

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>G5 Bygg AB | Byggentreprenör i Stockholm</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Urbanist:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page page--home">
+    <header class="site-header">
+        <div class="site-header__inner">
+            <a href="index.html" class="brand">G5 Bygg AB</a>
+            <nav class="nav" aria-label="Huvudmeny">
+                <a class="nav__link nav__link--active" href="index.html">Hem</a>
+                <a class="nav__link" href="tjanster.html">Tjänster</a>
+                <a class="nav__link" href="om-oss.html">Om oss</a>
+                <a class="nav__link" href="kontakt.html">Kontakt</a>
+            </nav>
+            <a class="nav__cta" href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero hero--home">
+            <div class="hero__overlay"></div>
+            <div class="hero__content">
+                <span class="hero__tag">Totalentreprenör</span>
+                <h1>Moderna bygglösningar för hållbara miljöer</h1>
+                <p>Vi levererar kvalitativa byggentreprenader med fokus på precision, trygghet och långsiktiga samarbeten i både bostads- och kommersiella projekt.</p>
+                <div class="hero__actions">
+                    <a class="button" href="tjanster.html">Utforska våra tjänster</a>
+                    <a class="button button--ghost" href="kontakt.html">Boka ett möte</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="intro">
+            <div class="container intro__grid">
+                <article class="intro__card">
+                    <h2>Byggpartner genom hela resan</h2>
+                    <p>G5 Bygg AB är din helhetsleverantör &mdash; från strategisk planering och projektering till produktion och avslutande byggservice. Vi hanterar entreprenader i såväl ABT06 som AB04 och skapar tydliga processer som håller budget, kvalitet och tid.</p>
+                    <p class="intro__sub">Kopplade till Fora, ID06 och företagshälsovården för säkra arbetsplatser.</p>
+                </article>
+                <article class="intro__highlights">
+                    <div>
+                        <h3>Helhetsgrepp</h3>
+                        <p>Nybyggnation, ombyggnad, tillbyggnader och specialistuppdrag inom solcellsmontage och byggservice.</p>
+                    </div>
+                    <div>
+                        <h3>Professionella team</h3>
+                        <p>Certifierade hantverkare och projektledare med vana av komplexa byggmiljöer.</p>
+                    </div>
+                    <div>
+                        <h3>Transparent process</h3>
+                        <p>Dedikerad kontaktperson, tydliga offerter och uppföljning i varje fas.</p>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="services-preview">
+            <div class="container">
+                <div class="section-heading">
+                    <span>Tjänster</span>
+                    <h2>Bredd och precision i varje uppdrag</h2>
+                </div>
+                <div class="services__grid">
+                    <article class="service-card">
+                        <h3>Ny- &amp; ombyggnation</h3>
+                        <p>Från enbostadshus till flerfamiljshus och kommersiella fastigheter med full projektledning.</p>
+                    </article>
+                    <article class="service-card">
+                        <h3>Tillbyggnader</h3>
+                        <p>Skalbara lösningar som sömlöst ansluter till befintliga konstruktioner.</p>
+                    </article>
+                    <article class="service-card">
+                        <h3>Hyresgäst- &amp; lokalanpassningar</h3>
+                        <p>Effektiva anpassningar som minimerar driftstopp för verksamheten.</p>
+                    </article>
+                    <article class="service-card">
+                        <h3>Solcellsmontage</h3>
+                        <p>Integrerade energilösningar med fokus på hållbar drift och estetik.</p>
+                    </article>
+                    <article class="service-card">
+                        <h3>Stambyten &amp; byggservice</h3>
+                        <p>Välplanerade underhålls- och serviceuppdrag med trygg kommunikation.</p>
+                    </article>
+                    <article class="service-card">
+                        <h3>Gipsentreprenad</h3>
+                        <p>Perfekta ytor och detaljer i allt från bostäder till offentliga miljöer.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="process">
+            <div class="container">
+                <div class="section-heading">
+                    <span>Process</span>
+                    <h2>Strukturerad metodik från start till mål</h2>
+                </div>
+                <div class="process__steps">
+                    <div class="step">
+                        <div class="step__number">01</div>
+                        <h3>Dialog &amp; behovsanalys</h3>
+                        <p>Vi sätter oss in i dina mål, ramar och tidsplan för att definiera rätt upplägg och entreprenadform.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step__number">02</div>
+                        <h3>Planering &amp; kalkyl</h3>
+                        <p>Transparent kostnadsbild, realistisk tidplan och noggrann riskhantering i varje fas.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step__number">03</div>
+                        <h3>Produktion &amp; leverans</h3>
+                        <p>Dedikerat projektteam säkerställer kvalitet, arbetsmiljö och samordning på plats.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="cta-band">
+            <div class="container cta-band__inner">
+                <div>
+                    <h2>Klara för nästa projekt?</h2>
+                    <p>Kontakta oss så berättar vi mer om hur vi kan hjälpa er med totalentreprenad eller utförandeentreprenad.</p>
+                </div>
+                <div class="cta-band__actions">
+                    <a class="button" href="kontakt.html">Kontakta oss</a>
+                    <a class="button button--ghost" href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer__content">
+            <div>
+                <h2>G5 Bygg AB</h2>
+                <p>Entreprenader med ansvar, kvalitet och tydlighet.</p>
+            </div>
+            <div class="footer__grid">
+                <div>
+                    <span class="footer__label">Telefon</span>
+                    <a href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+                </div>
+                <div>
+                    <span class="footer__label">E-post</span>
+                    <a href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                </div>
+                <div>
+                    <span class="footer__label">Organisationsnummer</span>
+                    <p>559541-6008</p>
+                </div>
+            </div>
+        </div>
+        <p class="footer__note">&copy; <span id="year"></span> G5 Bygg AB. Alla rättigheter förbehållna.</p>
+    </footer>
+
+    <script>
+        const yearElement = document.getElementById('year');
+        if (yearElement) {
+            yearElement.textContent = new Date().getFullYear();
+        }
+    </script>
+</body>
+</html>

--- a/kontakt.html
+++ b/kontakt.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kontakt | G5 Bygg AB</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Urbanist:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page page--contact">
+    <header class="site-header">
+        <div class="site-header__inner">
+            <a href="index.html" class="brand">G5 Bygg AB</a>
+            <nav class="nav" aria-label="Huvudmeny">
+                <a class="nav__link" href="index.html">Hem</a>
+                <a class="nav__link" href="tjanster.html">Tjänster</a>
+                <a class="nav__link" href="om-oss.html">Om oss</a>
+                <a class="nav__link nav__link--active" href="kontakt.html">Kontakt</a>
+            </nav>
+            <a class="nav__cta" href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero hero--subpage">
+            <div class="hero__overlay hero__overlay--contact"></div>
+            <div class="hero__content">
+                <span class="hero__tag">Kontakt</span>
+                <h1>Vi ser fram emot att prata bygg med dig</h1>
+                <p>Fyll i formuläret eller kontakta oss direkt via telefon eller e-post så återkommer vi snabbt.</p>
+            </div>
+        </section>
+
+        <section class="contact-section">
+            <div class="container contact-section__grid">
+                <article class="contact-card">
+                    <h2>Direktkontakt</h2>
+                    <div class="contact-card__item">
+                        <span class="contact-card__label">Telefon</span>
+                        <a href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+                    </div>
+                    <div class="contact-card__item">
+                        <span class="contact-card__label">E-post</span>
+                        <a href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                    </div>
+                    <div class="contact-card__item">
+                        <span class="contact-card__label">Organisationsnummer</span>
+                        <p>559541-6008</p>
+                    </div>
+                    <div class="contact-card__item">
+                        <span class="contact-card__label">Tillgänglighet</span>
+                        <p>Vi arbetar vardagar 07.00–17.00 och erbjuder jour via byggservice vid behov.</p>
+                    </div>
+                </article>
+                <form class="contact-form" aria-label="Kontaktformulär">
+                    <h2>Skicka en förfrågan</h2>
+                    <div class="form__row">
+                        <label for="name">Namn</label>
+                        <input id="name" name="name" type="text" placeholder="Ditt namn" required>
+                    </div>
+                    <div class="form__row">
+                        <label for="company">Företag</label>
+                        <input id="company" name="company" type="text" placeholder="Organisation eller förening">
+                    </div>
+                    <div class="form__row">
+                        <label for="email">E-post</label>
+                        <input id="email" name="email" type="email" placeholder="namn@foretag.se" required>
+                    </div>
+                    <div class="form__row">
+                        <label for="phone">Telefon</label>
+                        <input id="phone" name="phone" type="tel" placeholder="0700 000 000">
+                    </div>
+                    <div class="form__row">
+                        <label for="message">Beskriv projektet</label>
+                        <textarea id="message" name="message" rows="4" placeholder="Berätta kort om projektet och önskad tidplan"></textarea>
+                    </div>
+                    <p class="form__note">Genom att skicka formuläret samtycker du till att vi kontaktar dig via angivna uppgifter.</p>
+                    <button class="button" type="submit">Skicka förfrågan</button>
+                </form>
+            </div>
+        </section>
+
+        <section class="service-areas">
+            <div class="container service-areas__grid">
+                <article>
+                    <h2>Projektområden</h2>
+                    <p>Vi verkar främst i Stockholmsregionen men åtar oss även projekt i angränsande län efter överenskommelse.</p>
+                </article>
+                <article>
+                    <h2>Typ av uppdrag</h2>
+                    <ul>
+                        <li>Totalentreprenad och utförandeentreprenad</li>
+                        <li>Renoveringar och hyresgästanpassningar</li>
+                        <li>Serviceavtal och jouruppdrag</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="cta-band">
+            <div class="container cta-band__inner">
+                <div>
+                    <h2>Redo att ta nästa steg?</h2>
+                    <p>Ring oss direkt eller boka in ett digitalt möte så går vi igenom ert projekt.</p>
+                </div>
+                <div class="cta-band__actions">
+                    <a class="button" href="tel:+46700286215">Ring 0700&nbsp;286&nbsp;215</a>
+                    <a class="button button--ghost" href="mailto:info@g5bygg.com">Skicka e-post</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer__content">
+            <div>
+                <h2>G5 Bygg AB</h2>
+                <p>Entreprenader med ansvar, kvalitet och tydlighet.</p>
+            </div>
+            <div class="footer__grid">
+                <div>
+                    <span class="footer__label">Telefon</span>
+                    <a href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+                </div>
+                <div>
+                    <span class="footer__label">E-post</span>
+                    <a href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                </div>
+                <div>
+                    <span class="footer__label">Organisationsnummer</span>
+                    <p>559541-6008</p>
+                </div>
+            </div>
+        </div>
+        <p class="footer__note">&copy; <span id="year"></span> G5 Bygg AB. Alla rättigheter förbehållna.</p>
+    </footer>
+
+    <script>
+        const yearElement = document.getElementById('year');
+        if (yearElement) {
+            yearElement.textContent = new Date().getFullYear();
+        }
+    </script>
+</body>
+</html>

--- a/om-oss.html
+++ b/om-oss.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Om oss | G5 Bygg AB</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Urbanist:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page page--about">
+    <header class="site-header">
+        <div class="site-header__inner">
+            <a href="index.html" class="brand">G5 Bygg AB</a>
+            <nav class="nav" aria-label="Huvudmeny">
+                <a class="nav__link" href="index.html">Hem</a>
+                <a class="nav__link" href="tjanster.html">Tjänster</a>
+                <a class="nav__link nav__link--active" href="om-oss.html">Om oss</a>
+                <a class="nav__link" href="kontakt.html">Kontakt</a>
+            </nav>
+            <a class="nav__cta" href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero hero--subpage">
+            <div class="hero__overlay hero__overlay--about"></div>
+            <div class="hero__content">
+                <span class="hero__tag">Om G5 Bygg AB</span>
+                <h1>Byggpartner med fokus på långsiktigt värde</h1>
+                <p>Vi kombinerar modern projektstyrning med genuint hantverk för att skapa trygga, hållbara byggnader.</p>
+            </div>
+        </section>
+
+        <section class="about-overview">
+            <div class="container about-overview__grid">
+                <article>
+                    <h2>Vår filosofi</h2>
+                    <p>G5 Bygg AB grundades med ambitionen att leverera byggentreprenader där kunden upplever tydlighet, engagemang och omtanke i varje steg. Vi arbetar nära beställare, konsulter och leverantörer för att hitta smarta lösningar som håller över tid.</p>
+                    <p>Med väl inarbetade processer kan vi skala från mindre byggserviceuppdrag till omfattande totalentreprenader med bibehållen kvalitet.</p>
+                </article>
+                <aside class="about-stats">
+                    <div>
+                        <span class="about-stats__number">100%</span>
+                        <span class="about-stats__label">Fokus på arbetsmiljö</span>
+                    </div>
+                    <div>
+                        <span class="about-stats__number">24/7</span>
+                        <span class="about-stats__label">Byggservice vid behov</span>
+                    </div>
+                    <div>
+                        <span class="about-stats__number">ABT06 &amp; AB04</span>
+                        <span class="about-stats__label">Flexibla entreprenadformer</span>
+                    </div>
+                </aside>
+            </div>
+        </section>
+
+        <section class="values">
+            <div class="container">
+                <div class="section-heading">
+                    <span>Våra värderingar</span>
+                    <h2>Så bygger vi förtroende</h2>
+                </div>
+                <div class="values__grid">
+                    <article class="value-card">
+                        <h3>Ansvar</h3>
+                        <p>Vi tar ansvar för helheten och lämnar aldrig något åt slumpen. Våra projektledare följer upp varje detalj och säkerställer att avtalen följs.</p>
+                    </article>
+                    <article class="value-card">
+                        <h3>Transparens</h3>
+                        <p>Tydlig kommunikation, uppdaterade tidplaner och öppna kalkyler skapar trygghet för våra beställare.</p>
+                    </article>
+                    <article class="value-card">
+                        <h3>Hållbarhet</h3>
+                        <p>Vi prioriterar energieffektiva lösningar, ansvarsfulla materialval och arbetsmiljö i alla uppdrag.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="credentials">
+            <div class="container credentials__grid">
+                <article>
+                    <h2>Certifieringar &amp; partnerskap</h2>
+                    <ul>
+                        <li>Kopplade till Fora för trygg personalhantering.</li>
+                        <li>ID06-registrerade med säkra arbetsplatser.</li>
+                        <li>Samarbete med företagshälsovården för frisk och säker produktion.</li>
+                    </ul>
+                </article>
+                <article>
+                    <h2>Så arbetar vi</h2>
+                    <ul>
+                        <li>Tvärdisciplinära projektteam med tydliga ansvarsområden.</li>
+                        <li>Digital projektstyrning och dokumentation.</li>
+                        <li>Eftermarknadsprogram med service och uppföljning.</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="team-approach">
+            <div class="container team-approach__grid">
+                <article>
+                    <h2>Projektmetodik</h2>
+                    <p>Vi tar fram en projektplan tillsammans med beställaren och arbetar i nära dialog under hela resan. Genom att kombinera tydliga milstolpar med flexibilitet kan vi snabbt möta förändrade behov.</p>
+                </article>
+                <article class="timeline">
+                    <div class="timeline__item">
+                        <span class="timeline__step">1</span>
+                        <div>
+                            <h3>Uppstart</h3>
+                            <p>Gemensam målbild, riskanalys och resursplanering.</p>
+                        </div>
+                    </div>
+                    <div class="timeline__item">
+                        <span class="timeline__step">2</span>
+                        <div>
+                            <h3>Produktion</h3>
+                            <p>Koordinerade lag med fokus på kvalitet, arbetsmiljö och logistik.</p>
+                        </div>
+                    </div>
+                    <div class="timeline__item">
+                        <span class="timeline__step">3</span>
+                        <div>
+                            <h3>Överlämning</h3>
+                            <p>Noggrann besiktning, dokumentation och uppföljning.</p>
+                        </div>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="cta-band">
+            <div class="container cta-band__inner">
+                <div>
+                    <h2>Vill du veta mer om oss?</h2>
+                    <p>Låt oss berätta hur vi kan stötta ditt projekt från första mötet till färdig byggnad.</p>
+                </div>
+                <div class="cta-band__actions">
+                    <a class="button" href="kontakt.html">Kontakta oss</a>
+                    <a class="button button--ghost" href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer__content">
+            <div>
+                <h2>G5 Bygg AB</h2>
+                <p>Entreprenader med ansvar, kvalitet och tydlighet.</p>
+            </div>
+            <div class="footer__grid">
+                <div>
+                    <span class="footer__label">Telefon</span>
+                    <a href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+                </div>
+                <div>
+                    <span class="footer__label">E-post</span>
+                    <a href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                </div>
+                <div>
+                    <span class="footer__label">Organisationsnummer</span>
+                    <p>559541-6008</p>
+                </div>
+            </div>
+        </div>
+        <p class="footer__note">&copy; <span id="year"></span> G5 Bygg AB. Alla rättigheter förbehållna.</p>
+    </footer>
+
+    <script>
+        const yearElement = document.getElementById('year');
+        if (yearElement) {
+            yearElement.textContent = new Date().getFullYear();
+        }
+    </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,851 @@
+:root {
+    --bg: #0f172a;
+    --bg-light: #111b33;
+    --primary: #f1c40f;
+    --primary-soft: rgba(241, 196, 15, 0.18);
+    --text: #f8fafc;
+    --muted: #94a3b8;
+    --accent: #1e293b;
+    --max-width: 1100px;
+    font-size: 16px;
+    font-family: 'Urbanist', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+body.page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+.container {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.95rem 2.5rem;
+    border-radius: 999px;
+    background: var(--primary);
+    color: #0f172a;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+    box-shadow: 0 20px 40px rgba(241, 196, 15, 0.25);
+}
+
+.button:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 24px 55px rgba(241, 196, 15, 0.3);
+}
+
+.button--ghost {
+    background: transparent;
+    color: var(--text);
+    box-shadow: none;
+    border: 1px solid rgba(241, 196, 15, 0.35);
+}
+
+.button--ghost:hover {
+    background: rgba(241, 196, 15, 0.1);
+    transform: translateY(-2px);
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(15, 23, 42, 0.95);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.site-header__inner {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 2.5rem;
+}
+
+.brand {
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.95rem;
+}
+
+.nav {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex: 1;
+}
+
+.nav__link {
+    position: relative;
+    font-weight: 500;
+    color: var(--muted);
+    transition: color 0.3s ease;
+    padding: 0.25rem 0;
+}
+
+.nav__link::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -0.3rem;
+    width: 0;
+    height: 2px;
+    background: var(--primary);
+    transition: width 0.3s ease;
+}
+
+.nav__link:hover,
+.nav__link.nav__link--active {
+    color: var(--text);
+}
+
+.nav__link:hover::after,
+.nav__link.nav__link--active::after {
+    width: 100%;
+}
+
+.nav__cta {
+    border: 1px solid rgba(241, 196, 15, 0.3);
+    border-radius: 999px;
+    padding: 0.65rem 1.4rem;
+    font-weight: 600;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+.nav__cta:hover {
+    background: var(--primary);
+    color: #0f172a;
+}
+
+main {
+    flex: 1;
+    padding-bottom: 6rem;
+}
+
+.hero {
+    position: relative;
+    display: grid;
+    place-items: center;
+    padding: 8rem 1.5rem 6rem;
+    overflow: hidden;
+    background: radial-gradient(circle at top right, rgba(241, 196, 15, 0.25), transparent 55%),
+                linear-gradient(135deg, #1f2937 0%, #0b1120 60%);
+}
+
+.hero--home {
+    min-height: clamp(540px, 70vh, 680px);
+    text-align: center;
+}
+
+.hero--subpage {
+    min-height: 380px;
+    align-items: end;
+    padding-bottom: 4.5rem;
+}
+
+.hero__overlay {
+    position: absolute;
+    inset: 0;
+    background: url('https://images.unsplash.com/photo-1503389152951-9f343605f61e?auto=format&fit=crop&w=1600&q=80') center/cover;
+    opacity: 0.16;
+    filter: grayscale(100%);
+    mix-blend-mode: screen;
+}
+
+.hero__overlay--services {
+    background: url('https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1600&q=80') center/cover;
+}
+
+.hero__overlay--about {
+    background: url('https://images.unsplash.com/photo-1505731132164-cca9034a7c22?auto=format&fit=crop&w=1600&q=80') center/cover;
+}
+
+.hero__overlay--contact {
+    background: url('https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=1600&q=80') center/cover;
+}
+
+.hero__content {
+    position: relative;
+    max-width: 720px;
+    z-index: 1;
+}
+
+.hero--subpage .hero__content {
+    text-align: left;
+}
+
+.hero__tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 1rem;
+    border-radius: 999px;
+    background-color: var(--primary-soft);
+    color: var(--primary);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.hero h1 {
+    font-size: clamp(2.5rem, 4vw, 3.6rem);
+    font-weight: 700;
+    margin: 1.5rem 0 1rem;
+}
+
+.hero p {
+    color: var(--muted);
+    font-size: 1.1rem;
+}
+
+.hero__actions {
+    margin-top: 2.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.hero--subpage .hero__actions,
+.hero--subpage .hero__content {
+    justify-self: start;
+}
+
+.intro {
+    margin-top: -4rem;
+    position: relative;
+}
+
+.intro::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top, rgba(241, 196, 15, 0.12), transparent 55%);
+    z-index: -1;
+}
+
+.intro__grid {
+    display: grid;
+    gap: 2rem;
+    align-items: stretch;
+}
+
+.intro__card {
+    background: var(--bg-light);
+    padding: 3rem;
+    border-radius: 24px;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.4);
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.intro__card h2 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+}
+
+.intro__card p {
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.intro__sub {
+    margin-top: 1.5rem;
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.intro__highlights {
+    display: grid;
+    gap: 1.75rem;
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.5));
+    border-radius: 24px;
+    padding: 2.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.intro__highlights h3 {
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.intro__highlights p {
+    color: var(--muted);
+}
+
+.section-heading {
+    margin: 6rem 0 2.5rem;
+    text-align: left;
+}
+
+.section-heading span {
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    font-size: 0.75rem;
+    color: var(--primary);
+    font-weight: 700;
+}
+
+.section-heading h2 {
+    margin-top: 1rem;
+    font-size: clamp(2rem, 3vw, 2.8rem);
+}
+
+.services-preview {
+    margin-top: 4rem;
+}
+
+.services__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.services__grid--detailed {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.service-card {
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.45));
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    border-radius: 20px;
+    padding: 1.75rem;
+    transition: transform 0.3s ease, border-color 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.service-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(241, 196, 15, 0.28), transparent 55%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.service-card:hover {
+    transform: translateY(-6px);
+    border-color: rgba(241, 196, 15, 0.4);
+}
+
+.service-card:hover::after {
+    opacity: 1;
+}
+
+.service-card h3 {
+    font-size: 1.25rem;
+    margin-bottom: 0.6rem;
+}
+
+.service-card p {
+    color: var(--muted);
+    position: relative;
+    z-index: 1;
+}
+
+.service-card__list {
+    margin-top: 1.25rem;
+    list-style: none;
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 0.6rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.service-card__list li::before {
+    content: "\2022";
+    color: var(--primary);
+    margin-right: 0.6rem;
+}
+
+.process {
+    margin-top: 6rem;
+}
+
+.process__steps {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.step {
+    background: var(--bg-light);
+    border-radius: 20px;
+    padding: 2rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.step__number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: var(--primary-soft);
+    color: var(--primary);
+    font-weight: 700;
+    margin-bottom: 1.25rem;
+}
+
+.step h3 {
+    margin-bottom: 0.75rem;
+}
+
+.step p {
+    color: var(--muted);
+}
+
+.delivery-model {
+    margin-top: 5rem;
+}
+
+.delivery-model__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.delivery-model__card {
+    background: var(--bg-light);
+    border-radius: 24px;
+    padding: 2.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.delivery-model__card h2 {
+    margin-bottom: 1rem;
+}
+
+.delivery-model__card p {
+    color: var(--muted);
+    margin-bottom: 1.25rem;
+}
+
+.delivery-model__card ul {
+    list-style: none;
+    display: grid;
+    gap: 0.6rem;
+    color: var(--muted);
+}
+
+.delivery-model__card li::before {
+    content: "\2713";
+    color: var(--primary);
+    margin-right: 0.6rem;
+}
+
+.about-overview {
+    margin-top: 4rem;
+}
+
+.about-overview__grid {
+    display: grid;
+    gap: 2rem;
+    align-items: start;
+}
+
+.about-overview__grid article {
+    background: var(--bg-light);
+    padding: 2.75rem;
+    border-radius: 24px;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.about-overview__grid article p {
+    color: var(--muted);
+    margin-bottom: 1rem;
+}
+
+.about-stats {
+    display: grid;
+    gap: 1.5rem;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.5));
+    border-radius: 24px;
+    padding: 2.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.about-stats__number {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.about-stats__label {
+    display: block;
+    color: var(--muted);
+}
+
+.values {
+    margin-top: 6rem;
+}
+
+.values__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.value-card {
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.45));
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    border-radius: 20px;
+    padding: 2rem;
+}
+
+.value-card p {
+    color: var(--muted);
+    margin-top: 0.75rem;
+}
+
+.credentials {
+    margin-top: 5rem;
+}
+
+.credentials__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.credentials__grid article {
+    background: var(--bg-light);
+    border-radius: 24px;
+    padding: 2.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.credentials__grid ul {
+    list-style: none;
+    display: grid;
+    gap: 0.6rem;
+    color: var(--muted);
+}
+
+.credentials__grid li::before {
+    content: "\2022";
+    color: var(--primary);
+    margin-right: 0.6rem;
+}
+
+.team-approach {
+    margin-top: 5rem;
+}
+
+.team-approach__grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+}
+
+.team-approach__grid article {
+    background: var(--bg-light);
+    border-radius: 24px;
+    padding: 2.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.timeline {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.timeline__item {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+}
+
+.timeline__step {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: var(--primary-soft);
+    color: var(--primary);
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.timeline__item h3 {
+    margin-bottom: 0.4rem;
+}
+
+.timeline__item p {
+    color: var(--muted);
+}
+
+.contact-section {
+    margin-top: 4rem;
+}
+
+.contact-section__grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+}
+
+.contact-card,
+.contact-form {
+    background: var(--bg-light);
+    border-radius: 24px;
+    padding: 2.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.contact-card__item + .contact-card__item {
+    margin-top: 1.4rem;
+}
+
+.contact-card__label {
+    display: block;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--primary);
+    margin-bottom: 0.35rem;
+}
+
+.contact-card a,
+.contact-card p {
+    color: var(--muted);
+}
+
+.contact-form h2 {
+    margin-bottom: 1.5rem;
+}
+
+.form__row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.form__row label {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.form__row input,
+.form__row textarea {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    color: var(--text);
+    font: inherit;
+}
+
+.form__row input:focus,
+.form__row textarea:focus {
+    outline: none;
+    border-color: rgba(241, 196, 15, 0.6);
+    box-shadow: 0 0 0 3px rgba(241, 196, 15, 0.15);
+}
+
+.form__note {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-bottom: 1.5rem;
+}
+
+.service-areas {
+    margin-top: 4rem;
+}
+
+.service-areas__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.service-areas__grid article {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.45));
+    border-radius: 24px;
+    padding: 2.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.service-areas__grid p,
+.service-areas__grid li {
+    color: var(--muted);
+}
+
+.service-areas__grid ul {
+    list-style: none;
+    display: grid;
+    gap: 0.6rem;
+    margin-top: 1rem;
+}
+
+.service-areas__grid li::before {
+    content: "\2022";
+    color: var(--primary);
+    margin-right: 0.6rem;
+}
+
+.cta-band {
+    margin-top: 6rem;
+}
+
+.cta-band__inner {
+    background: linear-gradient(120deg, rgba(241, 196, 15, 0.18), rgba(15, 23, 42, 0.9));
+    border-radius: 28px;
+    padding: 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    border: 1px solid rgba(241, 196, 15, 0.3);
+}
+
+.cta-band__inner h2 {
+    font-size: 2rem;
+}
+
+.cta-band__inner p {
+    color: var(--muted);
+}
+
+.cta-band__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.site-footer {
+    border-top: 1px solid rgba(148, 163, 184, 0.1);
+    padding: 3rem 1.5rem 2rem;
+    background: rgba(15, 23, 42, 0.95);
+}
+
+.footer__content {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.footer__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.footer__label {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--primary);
+    margin-bottom: 0.3rem;
+}
+
+.footer__grid a,
+.footer__grid p {
+    color: var(--muted);
+}
+
+.footer__note {
+    text-align: center;
+    color: var(--muted);
+    margin-top: 2rem;
+    font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+    .site-header__inner {
+        flex-wrap: wrap;
+        gap: 1.25rem;
+        justify-content: space-between;
+    }
+
+    .nav {
+        flex: 1 1 100%;
+        order: 3;
+        justify-content: center;
+    }
+
+    .nav__cta {
+        order: 2;
+    }
+
+    .hero--subpage .hero__content,
+    .hero__content {
+        text-align: center;
+    }
+
+    .hero--subpage .hero__actions,
+    .hero__actions {
+        justify-content: center;
+    }
+
+    .intro {
+        margin-top: -2rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .site-header__inner {
+        padding: 1rem 1.25rem;
+    }
+
+    .button {
+        width: 100%;
+    }
+
+    .intro__card,
+    .intro__highlights,
+    .delivery-model__card,
+    .team-approach__grid article,
+    .contact-card,
+    .contact-form,
+    .credentials__grid article {
+        padding: 2rem;
+    }
+
+    .cta-band__inner {
+        padding: 2.5rem;
+    }
+}

--- a/tjanster.html
+++ b/tjanster.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tjänster | G5 Bygg AB</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Urbanist:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page page--services">
+    <header class="site-header">
+        <div class="site-header__inner">
+            <a href="index.html" class="brand">G5 Bygg AB</a>
+            <nav class="nav" aria-label="Huvudmeny">
+                <a class="nav__link" href="index.html">Hem</a>
+                <a class="nav__link nav__link--active" href="tjanster.html">Tjänster</a>
+                <a class="nav__link" href="om-oss.html">Om oss</a>
+                <a class="nav__link" href="kontakt.html">Kontakt</a>
+            </nav>
+            <a class="nav__cta" href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero hero--subpage">
+            <div class="hero__overlay hero__overlay--services"></div>
+            <div class="hero__content">
+                <span class="hero__tag">Våra tjänster</span>
+                <h1>Hela kedjan från idé till färdig byggnad</h1>
+                <p>Som total- och utförandeentreprenör erbjuder vi ett komplett tjänsteutbud för bostäder, kommersiella fastigheter och offentliga miljöer.</p>
+                <div class="hero__actions">
+                    <a class="button" href="kontakt.html">Starta projekt</a>
+                    <a class="button button--ghost" href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="services-detail">
+            <div class="container">
+                <div class="section-heading">
+                    <span>Helhetslösningar</span>
+                    <h2>Entreprenader som täcker varje behov</h2>
+                </div>
+                <div class="services__grid services__grid--detailed">
+                    <article class="service-card">
+                        <h3>Nybyggnation</h3>
+                        <p>Planering, projektering och produktion av enbostadshus, flerfamiljshus och kommersiella fastigheter.</p>
+                        <ul class="service-card__list">
+                            <li>Projekteringsledning och bygglovshantering</li>
+                            <li>Samordning av arkitekter och tekniska konsulter</li>
+                            <li>Strikt kvalitets- och arbetsmiljöstyrning</li>
+                        </ul>
+                    </article>
+                    <article class="service-card">
+                        <h3>Ombyggnation &amp; renovering</h3>
+                        <p>Modernisering av befintliga miljöer för bostäder, kontor och kommersiella lokaler.</p>
+                        <ul class="service-card__list">
+                            <li>Omfattande ombyggnationer och stambyten</li>
+                            <li>Interiöra uppgraderingar med fokus på funktion</li>
+                            <li>Fasader, tak och energieffektivisering</li>
+                        </ul>
+                    </article>
+                    <article class="service-card">
+                        <h3>Tillbyggnationer</h3>
+                        <p>Arkitektur och konstruktion som kompletterar befintliga fastigheter med hållbara tillägg.</p>
+                        <ul class="service-card__list">
+                            <li>Kapacitetsökning för verksamheter</li>
+                            <li>Förlängningar och påbyggnader</li>
+                            <li>Integrerad projektering och produktion</li>
+                        </ul>
+                    </article>
+                    <article class="service-card">
+                        <h3>Hyresgästanpassningar</h3>
+                        <p>Snabb och koordinerad anpassning av lokaler för nya hyresgäster med minimal driftspåverkan.</p>
+                        <ul class="service-card__list">
+                            <li>Kontor, butiker och offentliga miljöer</li>
+                            <li>Logistikstyrning och tidskritiska faser</li>
+                            <li>Eftermarknad och serviceavtal</li>
+                        </ul>
+                    </article>
+                    <article class="service-card">
+                        <h3>Lokalanpassningar</h3>
+                        <p>Skräddarsydda lösningar för effektivare arbetsplatser, butiker och produktionsmiljöer.</p>
+                        <ul class="service-card__list">
+                            <li>Funktionsanalys och layoutarbete</li>
+                            <li>Installationer, ventilation och el</li>
+                            <li>Inredning och specialsnickerier</li>
+                        </ul>
+                    </article>
+                    <article class="service-card">
+                        <h3>Solcellsmontage</h3>
+                        <p>Dimensionering och installation av solcellssystem som integreras i byggnadens helhet.</p>
+                        <ul class="service-card__list">
+                            <li>Teknisk förstudie och kalkyl</li>
+                            <li>Montage på tak och fasad</li>
+                            <li>Driftsättning och uppföljning</li>
+                        </ul>
+                    </article>
+                    <article class="service-card">
+                        <h3>Gipsentreprenad</h3>
+                        <p>Precision i väggar, tak och designade detaljer för både bostads- och kommersiella miljöer.</p>
+                        <ul class="service-card__list">
+                            <li>Akustikväggar och brandklassade system</li>
+                            <li>Komplexa former och speciallösningar</li>
+                            <li>Slutfinish i toppklass</li>
+                        </ul>
+                    </article>
+                    <article class="service-card">
+                        <h3>Byggservice</h3>
+                        <p>Flexibla team för löpande underhåll, akutinsatser och mindre projekt.</p>
+                        <ul class="service-card__list">
+                            <li>Serviceavtal och jourarbeten</li>
+                            <li>Snickeri, måleri och installationsarbeten</li>
+                            <li>Proaktivt underhåll för fastighetsägare</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="delivery-model">
+            <div class="container delivery-model__grid">
+                <article class="delivery-model__card">
+                    <h2>Entreprenadformer</h2>
+                    <p>Vi utför entreprenader i både ABT06- och AB04-former och anpassar upplägget efter projektets omfattning och önskad riskfördelning.</p>
+                    <ul>
+                        <li>Totalentreprenad med helhetsansvar</li>
+                        <li>Utförandeentreprenad i nära samarbete med beställare</li>
+                        <li>Partnering för komplexa och långsiktiga projekt</li>
+                    </ul>
+                </article>
+                <article class="delivery-model__card">
+                    <h2>Tryggt genomförande</h2>
+                    <p>Som anslutna till Fora, ID06 och företagshälsovården prioriterar vi arbetsmiljö och säkerhet i varje steg.</p>
+                    <ul>
+                        <li>Systematiskt arbetsmiljöarbete</li>
+                        <li>Kvalitetssäkring och egenkontroller</li>
+                        <li>Tydlig rapportering och kommunikation</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="cta-band">
+            <div class="container cta-band__inner">
+                <div>
+                    <h2>Behöver du en flexibel byggpartner?</h2>
+                    <p>Berätta om ert projekt så tar vi fram förslag på upplägg, tidsplan och budget.</p>
+                </div>
+                <div class="cta-band__actions">
+                    <a class="button" href="kontakt.html">Kontakta oss</a>
+                    <a class="button button--ghost" href="tel:+46700286215">Ring oss</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer__content">
+            <div>
+                <h2>G5 Bygg AB</h2>
+                <p>Entreprenader med ansvar, kvalitet och tydlighet.</p>
+            </div>
+            <div class="footer__grid">
+                <div>
+                    <span class="footer__label">Telefon</span>
+                    <a href="tel:+46700286215">0700&nbsp;286&nbsp;215</a>
+                </div>
+                <div>
+                    <span class="footer__label">E-post</span>
+                    <a href="mailto:info@g5bygg.com">info@g5bygg.com</a>
+                </div>
+                <div>
+                    <span class="footer__label">Organisationsnummer</span>
+                    <p>559541-6008</p>
+                </div>
+            </div>
+        </div>
+        <p class="footer__note">&copy; <span id="year"></span> G5 Bygg AB. Alla rättigheter förbehållna.</p>
+    </footer>
+
+    <script>
+        const yearElement = document.getElementById('year');
+        if (yearElement) {
+            yearElement.textContent = new Date().getFullYear();
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert the single landing page into a multi-page site with navigation linking to hem, tjänster, om oss och kontakt
- add detailed content for services, company profile, and contact including formulär, trygghet och entreprenadformer
- refresh the shared styling with a sticky header, footer, CTA-band and responsive card/grid layouts for all sidor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d927117a4c83289b30126344c533f8