### PR TITLE
Add meta descriptions to primary pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="description"
+    content="G5 Bygg AB levererar totalentreprenader i Stockholm med fokus på hållbara bygglösningar, tydliga processer och helhetsansvar från planering till service."
+  />
   <title>G5 Bygg AB | Byggentreprenör i Stockholm</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/kontakt.html
+++ b/kontakt.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Kontakta G5 Bygg AB för offerter, byggservice och projektstart – fyll i formuläret eller nå oss via telefon och e-post." />
     <title>Kontakt | G5 Bygg AB</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/om-oss.html
+++ b/om-oss.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Läs om G5 Bygg AB:s filosofi, värderingar och arbetssätt som kombinerar modern projektstyrning med gediget hantverk för hållbara resultat." />
     <title>Om oss | G5 Bygg AB</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tjanster.html
+++ b/tjanster.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Upptäck G5 Bygg AB:s tjänster – från nybyggnation och ombyggnad till solcellsmontage, byggservice och hyresgästanpassningar i Stockholm." />
     <title>Tjänster | G5 Bygg AB</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add meta description tags to home, services, about and contact pages with page-specific summaries

## Testing
- npx --yes lighthouse http://127.0.0.1:8000/index.html --only-categories=seo --quiet --chrome-flags="--headless" *(fails: npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9520d54a883289b40dd8a99274bd2