### PR TITLE
Add SMTP-backed contact endpoint and update form submission

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Server configuration
+PORT=3000
+
+# SMTP configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=api@example.com
+SMTP_PASS=super-secret-password
+
+# Sender and recipient
+MAIL_FROM="G5 Bygg AB <info@g5bygg.se>"
+CONTACT_RECIPIENT=info@g5bygg.se

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
+# G5 Bygg AB – webbplats och kontakt-API
 
+Detta projekt innehåller G5 Bygg AB:s marknadsföringssida samt ett enkelt Node.js-API för att ta emot kontaktförfrågningar och skicka e-post via SMTP.
+
+## Kom igång
+
+1. Installera beroenden:
+   ```bash
+   npm install
+   ```
+2. Skapa en `.env` baserat på `.env.example` och fyll i dina SMTP-uppgifter.
+3. Starta servern lokalt:
+   ```bash
+   npm start
+   ```
+4. Besök `http://localhost:3000/kontakt.html` och testa att skicka formuläret.
+
+## Miljövariabler
+
+| Variabel | Beskrivning |
+| --- | --- |
+| `PORT` | Valfri port för Express-servern (standard `3000`). |
+| `SMTP_HOST` | SMTP-serverns värdnamn. |
+| `SMTP_PORT` | Porten för SMTP-servern. |
+| `SMTP_SECURE` | Sätt till `true` om SMTP-servern kräver SSL (t.ex. port 465). |
+| `SMTP_USER` | SMTP-användarnamn eller API-nyckel. |
+| `SMTP_PASS` | SMTP-lösenord eller hemlighet. |
+| `MAIL_FROM` | Avsändaradress som visas i e-postmeddelandet. Faller tillbaka till `SMTP_USER`. |
+| `CONTACT_RECIPIENT` | Mottagarens e-postadress. Faller tillbaka till `SMTP_USER`. |
+
+## Kontakt-API
+
+- **Endpoint:** `POST /api/contact`
+- **Payload:** JSON med fälten `first_name`, `last_name`, `email`, `phone` (valfritt) och `message`.
+- **Svar:**
+  - `200 OK` – `{ "message": "Tack! ..." }`
+  - `400 Bad Request` – `{ "error": "..." }` när validering misslyckas.
+  - `500 Internal Server Error` – `{ "error": "..." }` när e-posttjänsten inte kan nås eller misslyckas.
+
+## Utveckling
+
+Använd `npm run dev` för att starta servern med [nodemon](https://github.com/remy/nodemon) och automatiska omstarter vid filändringar.

--- a/kontakt.html
+++ b/kontakt.html
@@ -57,7 +57,7 @@
                         <p>Vi arbetar vardagar 07.00–17.00 och erbjuder jour via byggservice vid behov.</p>
                     </div>
                 </article>
-                <form class="contact-form" id="kontaktform" aria-label="Kontaktformulär" action="mailto:info@g5bygg.se" method="post" enctype="text/plain">
+                <form class="contact-form" id="kontaktform" aria-label="Kontaktformulär" action="/api/contact" method="post" enctype="application/x-www-form-urlencoded">
                     <h2>Skicka en förfrågan</h2>
                     <div class="form__row form__row--split">
                         <div>
@@ -82,6 +82,7 @@
                         <textarea id="message" name="message" rows="5" placeholder="Berätta kort om projektet och önskad tidplan" required></textarea>
                     </div>
                     <p class="form__note">Genom att skicka formuläret samtycker du till att vi kontaktar dig via angivna uppgifter.</p>
+                    <p class="form__status" id="form-status" role="status" aria-live="polite" hidden></p>
                     <button class="button" type="submit">Skicka meddelande</button>
                 </form>
             </div>
@@ -146,6 +147,64 @@
         const yearElement = document.getElementById('year');
         if (yearElement) {
             yearElement.textContent = new Date().getFullYear();
+        }
+
+        const contactForm = document.getElementById('kontaktform');
+        const statusElement = document.getElementById('form-status');
+
+        if (contactForm && statusElement) {
+            contactForm.addEventListener('submit', async (event) => {
+                event.preventDefault();
+
+                const submitButton = contactForm.querySelector('button[type="submit"]');
+                if (submitButton) {
+                    submitButton.disabled = true;
+                    submitButton.textContent = 'Skickar...';
+                }
+
+                statusElement.hidden = false;
+                statusElement.textContent = 'Skickar ditt meddelande...';
+                statusElement.className = 'form__status form__status--info';
+
+                const formData = new FormData(contactForm);
+                const payload = Object.fromEntries(formData.entries());
+
+                try {
+                    const response = await fetch(contactForm.action, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(payload)
+                    });
+
+                    if (!response.ok) {
+                        let errorMessage = 'Något gick fel. Försök igen senare.';
+                        try {
+                            const errorData = await response.json();
+                            if (errorData && errorData.error) {
+                                errorMessage = errorData.error;
+                            }
+                        } catch (parseError) {
+                            // ignore parsing errors and use default message
+                        }
+                        throw new Error(errorMessage);
+                    }
+
+                    const data = await response.json();
+                    statusElement.textContent = data.message || 'Tack! Vi hör av oss så snart vi kan.';
+                    statusElement.className = 'form__status form__status--success';
+                    contactForm.reset();
+                } catch (error) {
+                    statusElement.textContent = error.message || 'Något gick fel. Försök igen senare.';
+                    statusElement.className = 'form__status form__status--error';
+                } finally {
+                    if (submitButton) {
+                        submitButton.disabled = false;
+                        submitButton.textContent = 'Skicka meddelande';
+                    }
+                }
+            });
         }
     </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "g5sida",
+  "version": "1.0.0",
+  "description": "Marknadsföringssida för G5 Bygg AB med kontakt-API för e-post.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "keywords": [
+    "kontakt",
+    "bygg",
+    "express",
+    "nodemailer"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "nodemailer": "^6.9.13"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.4"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,129 @@
+const path = require('path');
+const express = require('express');
+const nodemailer = require('nodemailer');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname)));
+
+let mailTransporter;
+
+function getTransporter() {
+  if (mailTransporter) {
+    return mailTransporter;
+  }
+
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_SECURE } = process.env;
+
+  if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS) {
+    throw new Error('E-posttjänsten är inte korrekt konfigurerad. Kontrollera SMTP-uppgifterna.');
+  }
+
+  const secure = SMTP_SECURE ? SMTP_SECURE.toLowerCase() === 'true' : Number(SMTP_PORT) === 465;
+
+  mailTransporter = nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT),
+    secure,
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASS
+    }
+  });
+
+  return mailTransporter;
+}
+
+function escapeHtml(input = '') {
+  return String(input)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function buildMessageBody({ first_name, last_name, phone, email, message }) {
+  const fullName = [first_name, last_name].filter(Boolean).join(' ');
+
+  const text = `Nytt meddelande från kontaktformuläret på g5bygg.se\n\n` +
+    `Namn: ${fullName}\n` +
+    (phone ? `Telefon: ${phone}\n` : '') +
+    `E-post: ${email}\n\n` +
+    `Meddelande:\n${message}`;
+
+  const html = `<!doctype html>
+  <html lang="sv">
+    <body>
+      <h2>Nytt meddelande från kontaktformuläret</h2>
+      <p><strong>Namn:</strong> ${escapeHtml(fullName)}</p>
+      ${phone ? `<p><strong>Telefon:</strong> ${escapeHtml(phone)}</p>` : ''}
+      <p><strong>E-post:</strong> ${escapeHtml(email)}</p>
+      <h3>Meddelande</h3>
+      <p>${escapeHtml(message).replace(/\n/g, '<br>')}</p>
+    </body>
+  </html>`;
+
+  return { text, html, subject: `Ny kontaktförfrågan från ${fullName || 'okänd avsändare'}` };
+}
+
+app.post('/api/contact', async (req, res) => {
+  const firstName = (req.body?.first_name || '').toString().trim();
+  const lastName = (req.body?.last_name || '').toString().trim();
+  const email = (req.body?.email || '').toString().trim();
+  const message = (req.body?.message || '').toString().trim();
+  const phone = (req.body?.phone || '').toString().trim();
+
+  if (!firstName || !lastName || !email || !message) {
+    return res.status(400).json({ error: 'Vänligen fyll i namn, efternamn, e-post och meddelande.' });
+  }
+
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(email)) {
+    return res.status(400).json({ error: 'E-postadressen verkar ogiltig. Kontrollera och försök igen.' });
+  }
+
+  if (message.length > 5000) {
+    return res.status(400).json({ error: 'Meddelandet är för långt. Försök korta ner det något.' });
+  }
+
+  try {
+    const transporter = getTransporter();
+    const { text, html, subject } = buildMessageBody({
+      first_name: firstName,
+      last_name: lastName,
+      email,
+      message,
+      phone
+    });
+
+    await transporter.sendMail({
+      from: process.env.MAIL_FROM || process.env.SMTP_USER,
+      to: process.env.CONTACT_RECIPIENT || process.env.SMTP_USER,
+      replyTo: email,
+      subject,
+      text,
+      html
+    });
+
+    return res.json({ message: 'Tack! Ditt meddelande har skickats och vi återkommer snarast.' });
+  } catch (error) {
+    console.error('Fel vid utskick av e-post:', error);
+    return res.status(500).json({ error: 'Vi kunde inte skicka ditt meddelande just nu. Försök igen senare.' });
+  }
+});
+
+app.use((err, req, res, next) => {
+  console.error('Internt serverfel:', err);
+  res.status(500).json({ error: 'Ett internt fel uppstod.' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Servern är igång på http://localhost:${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -393,6 +393,39 @@ main { padding: 0 1.5rem 6rem; }
   color: var(--muted);
 }
 
+.form__status {
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  background: rgba(82, 96, 109, 0.1);
+  color: var(--text);
+  transition: opacity 0.2s ease;
+}
+
+.form__status[hidden] {
+  display: none;
+}
+
+.form__status--info {
+  background: rgba(82, 96, 109, 0.08);
+  border-color: rgba(82, 96, 109, 0.2);
+  color: var(--muted);
+}
+
+.form__status--success {
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+  color: #047857;
+}
+
+.form__status--error {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
 .service-areas {
   margin: 6rem auto 0;
   max-width: var(--max-width);


### PR DESCRIPTION
## Summary
- add an Express server with a POST /api/contact endpoint that sends emails through SMTP using nodemailer
- document environment variables, add an example .env file, and ignore runtime artifacts
- update the contact form to submit via fetch and provide inline success/error feedback styling

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68d9520e3a1483288ce388a2177b517b