### PR TITLE
Update default contact email to g5bygg.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,5 @@ SMTP_USER=api@example.com
 SMTP_PASS=super-secret-password
 
 # Sender and recipient
-MAIL_FROM="G5 Bygg AB <info@g5bygg.se>"
-CONTACT_RECIPIENT=info@g5bygg.se
+MAIL_FROM="G5 Bygg AB <info@g5bygg.com>"
+CONTACT_RECIPIENT=info@g5bygg.com


### PR DESCRIPTION
## Summary
- update the example environment configuration to use the new info@g5bygg.com address for the sender and recipient defaults

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d98fab6f408328bf6b00fd426eb6b8