### PR TITLE
Update contact form action and reply-to handling

### DIFF
--- a/kontakt.html
+++ b/kontakt.html
@@ -101,12 +101,13 @@
                 </article>
 
                 <!-- FORM: statiskt (GitHub Pages) + FormSubmit AJAX -->
-                <form class="contact-form" id="kontaktform" aria-label="Kontaktformulär" action="https://formsubmit.co/62d03eedec7087f3209040e843a52c0e" method="post" autocomplete="on" accept-charset="UTF-8" novalidate>
+                <form class="contact-form" id="kontaktform" aria-label="Kontaktformulär" action="https://formsubmit.co/info@g5bygg.com" method="POST" autocomplete="on" accept-charset="UTF-8" novalidate>
                     <h2>Skicka en förfrågan</h2>
                     <input type="hidden" name="_next" value="https://g5bygg.com/tack.html">
                     <input type="hidden" name="_subject" value="Ny förfrågan via G5 Byggs hemsida!">
                     <input type="hidden" name="_captcha" value="false">
                     <input type="hidden" name="_template" value="table">
+                    <input type="hidden" id="reply-to" name="_replyto" value="">
                     <input type="text" name="_honey" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true">
 
                     <div class="form__row form__row--split">
@@ -200,6 +201,17 @@
     const yearElement = document.getElementById('year');
     if (yearElement) {
         yearElement.textContent = new Date().getFullYear();
+    }
+
+    // Synka Reply-To med angiven e-post
+    const contactForm = document.getElementById('kontaktform');
+    const emailField = document.getElementById('email');
+    const replyToField = document.getElementById('reply-to');
+
+    if (contactForm && emailField && replyToField) {
+        contactForm.addEventListener('submit', () => {
+            replyToField.value = emailField.value.trim();
+        });
     }
 </script>
 


### PR DESCRIPTION
## Summary
- update contact form action to point directly to info@g5bygg.com for FormSubmit
- add hidden reply-to field populated from the email input before submit
- keep existing FormSubmit configuration for redirects and spam protection

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d954cb4108329b81d8be4154a535a)