### PR TITLE
Bygg om kontaktformuläret — ersätt FormSubmit med klientside mailto-utkast

### DIFF
--- a/kontakt.html
+++ b/kontakt.html
@@ -100,43 +100,43 @@
                     </div>
                 </article>
 
-                <!-- FORM: statiskt (GitHub Pages) + FormSubmit AJAX -->
-                <form class="contact-form" id="kontaktform" aria-label="Kontaktformulär" action="https://formsubmit.co/info@g5bygg.com" method="POST" autocomplete="on" accept-charset="UTF-8" novalidate>
+                <!-- Nytt kontaktformulär: klientsidehantering utan extern formulärtjänst -->
+                <form class="contact-form" id="kontaktform" aria-label="Kontaktformulär" autocomplete="on" accept-charset="UTF-8">
                     <h2>Skicka en förfrågan</h2>
-                    <input type="hidden" name="_next" value="https://g5bygg.com/tack.html">
-                    <input type="hidden" name="_subject" value="Ny förfrågan via G5 Byggs hemsida!">
-                    <input type="hidden" name="_captcha" value="false">
-                    <input type="hidden" name="_template" value="table">
-                    <input type="hidden" id="reply-to" name="_replyto" value="">
-                    <input type="text" name="_honey" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true">
 
                     <div class="form__row form__row--split">
                         <div>
-                            <label for="first-name">Namn</label>
-                            <input id="first-name" name="first_name" type="text" placeholder="Ditt namn" autocomplete="given-name" required>
+                            <label for="name">Namn</label>
+                            <input id="name" name="name" type="text" placeholder="Ditt namn" autocomplete="name" required>
                         </div>
                         <div>
-                            <label for="last-name">Efternamn</label>
-                            <input id="last-name" name="last_name" type="text" placeholder="Ditt efternamn" autocomplete="family-name" required>
+                            <label for="phone">Telefon</label>
+                            <input id="phone" name="phone" type="tel" placeholder="0700 000 000" autocomplete="tel" inputmode="tel" pattern="[0-9 +()-]{6,}" required>
                         </div>
-                    </div>
-                    <div class="form__row">
-                        <label for="phone">Telefon</label>
-                        <input id="phone" name="phone" type="tel" placeholder="0700 000 000" autocomplete="tel" inputmode="tel" pattern="[0-9 +()-]{6,}">
                     </div>
                     <div class="form__row">
                         <label for="email">E-post</label>
                         <input id="email" name="email" type="email" placeholder="namn@foretag.com" autocomplete="email" required>
                     </div>
                     <div class="form__row">
+                        <label for="project-type">Typ av uppdrag</label>
+                        <select id="project-type" name="project_type" required>
+                            <option value="" selected disabled>Välj uppdragstyp</option>
+                            <option>Renovering</option>
+                            <option>Nybyggnation</option>
+                            <option>Service / underhåll</option>
+                            <option>Övrigt</option>
+                        </select>
+                    </div>
+                    <div class="form__row">
                         <label for="message">Meddelande</label>
-                        <textarea id="message" name="message" rows="5" placeholder="Berätta kort om projektet och önskad tidplan" autocomplete="on" required></textarea>
+                        <textarea id="message" name="message" rows="5" placeholder="Berätta kort om projektet och önskad tidplan" required></textarea>
                     </div>
 
-                    <p class="form__note">Genom att skicka formuläret samtycker du till att vi kontaktar dig via angivna uppgifter.</p>
+                    <p class="form__note">När du skickar öppnas ditt e-postprogram med ett färdigt meddelande till oss. Fungerar inte det, ring oss direkt på 0700 286 215.</p>
 
                     <p class="form__status" id="form-status" role="status" aria-live="polite" hidden></p>
-                    <button class="button" type="submit">Skicka meddelande</button>
+                    <button class="button" type="submit">Skicka förfrågan</button>
                 </form>
             </div>
         </section>
@@ -203,14 +203,47 @@
         yearElement.textContent = new Date().getFullYear();
     }
 
-    // Synka Reply-To med angiven e-post
+    // Ny formulärhantering: bygger ett mailto-utkast utan extern tjänst
     const contactForm = document.getElementById('kontaktform');
-    const emailField = document.getElementById('email');
-    const replyToField = document.getElementById('reply-to');
+    const statusField = document.getElementById('form-status');
 
-    if (contactForm && emailField && replyToField) {
-        contactForm.addEventListener('submit', () => {
-            replyToField.value = emailField.value.trim();
+    if (contactForm && statusField) {
+        contactForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+
+            if (!contactForm.checkValidity()) {
+                contactForm.reportValidity();
+                return;
+            }
+
+            const name = document.getElementById('name').value.trim();
+            const phone = document.getElementById('phone').value.trim();
+            const email = document.getElementById('email').value.trim();
+            const projectType = document.getElementById('project-type').value.trim();
+            const message = document.getElementById('message').value.trim();
+
+            const subject = encodeURIComponent(`Ny förfrågan: ${projectType}`);
+            const body = encodeURIComponent(
+                `Namn: ${name}
+` +
+                `Telefon: ${phone}
+` +
+                `E-post: ${email}
+` +
+                `Typ av uppdrag: ${projectType}
+
+` +
+                `Meddelande:
+${message}`
+            );
+
+            window.location.href = `mailto:info@g5bygg.com?subject=${subject}&body=${body}`;
+
+            statusField.hidden = false;
+            statusField.classList.remove('form__status--error');
+            statusField.classList.add('form__status--success');
+            statusField.textContent = 'Tack! Ditt e-postutkast är öppnat. Om inget händer, maila oss direkt på info@g5bygg.com eller ring 0700 286 215.';
+            contactForm.reset();
         });
     }
 </script>

--- a/styles.css
+++ b/styles.css
@@ -206,13 +206,13 @@ main { padding: 0 1.5rem 6rem; }
 
 .form__row label { display: block; font-weight: 600; color: var(--text); }
 
-.form__row input, .form__row textarea {
+.form__row input, .form__row textarea, .form__row select {
   width: 100%; border-radius: 16px; border: 1px solid var(--accent); padding: .85rem 1rem;
   font-size: 1rem; background: #fdfdfd; transition: border-color .2s ease, box-shadow .2s ease;
 }
 .form__row textarea { resize: vertical; min-height: 140px; }
 
-.form__row input:focus, .form__row textarea:focus {
+.form__row input:focus, .form__row textarea:focus, .form__row select:focus {
   outline: none; border-color: rgba(122,31,43,.6); box-shadow: 0 0 0 4px rgba(122,31,43,.12);
 }
 


### PR DESCRIPTION
### Motivation
- Det gamla FormSubmit-baserade formuläret fungerade inte på sidan och behövde ersättas med ett enklare, mer robustt flöde utan extern tjänst.
- Målet var ett tydligare formulär med färre externa beroenden och enklare hantering för användaren (öppnar e-postklient med ett färdigt utkast).

### Description
- Ersätter det gamla FormSubmit-formuläret i `kontakt.html` med ett nytt formulär som innehåller `namn`, `telefon`, `e-post`, `typ av uppdrag` och `meddelande` samt ny knapptext och hjälptext. (fil: `kontakt.html`).
- Tar bort FormSubmit-specifika dolda fält och `reply-to`-logik och lägger till ny klient-side JavaScript som validerar formuläret och bygger ett `mailto:`-utkast till `info@g5bygg.com` innan det öppnas i användarens e-postklient. (fil: `kontakt.html`).
- Uppdaterar CSS så att även `<select>`-element matchar befintlig input/textarea-design och fokus-stil för konsekvent utseende. (fil: `styles.css`).

### Testing
- Körde `node --check server.js` för att verifiera serverfilens syntax, vilket lyckades.
- Startade servern med `node server.js` och körde ett automatiserat Playwright-skript som laddade `http://127.0.0.1:3000/kontakt.html` och sparade en screenshot för visuell verifikation, vilket lyckades (screenshot sparad som artifact vid körning).
- Alla ovanstående automatiska verifieringar kördes utan fel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a686ce94083299a91a9559a25f03f)